### PR TITLE
Import Travis-ci to automatically test patches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: enabled
+os: linux
+
+language: python
+python:
+  - "3.4"
+  - "3.5"
+  - "3.6"
+
+before_install: true # Skip this phase
+
+# command to install dependencies
+install: true
+#  - ./install-dependencies.sh
+
+script:
+  - python -m unittest -v tests.scheduler_test tests.roulette_test # tests.mail_test tests.reader_test


### PR DESCRIPTION
Travis-ci is a company and provides CI services for us to automatically examine patches whether pass particular test cases.