### PR TITLE
Update string formatting style

### DIFF
--- a/reader/NFC/ACR122/uid.py
+++ b/reader/NFC/ACR122/uid.py
@@ -20,16 +20,16 @@ class ReadUidObserver(observer.GenericObserver):
         card.connection.connect()
 
         resp, sw1, sw2 = card.connection.transmit(GETDATA)
-        print(resp, "%.2x %.2x" %(sw1, sw2))
+        print('{0} {1:.2x} {2:.2x}'.format(resp, sw1, sw2))
 
 
     def insert_action(self, card):
-        print('+Inserted: ', toHexString(card.atr))
+        print('+Inserted: {0}'.format(toHexString(card.atr)))
         if card not in self.__cards:
             self.__cards += [card]
             self.readUid(card)
 
     def remove_action(self, card):
-        print('-Removed: ', toHexString(card.atr))
+        print('-Removed: {0}'.format(toHexString(card.atr)))
         if card in self.__cards:
             self.__cards.remove(card)

--- a/scheduler/scheduler.py
+++ b/scheduler/scheduler.py
@@ -10,9 +10,9 @@ class Scheduler:
 
     def show(self):
         print('*' * 20)
-        print('Total Event Number: %d\n' %len(self.__sched_obj.queue))
+        print('Total Event Number: {0:d}\n'.format(len(self.__sched_obj.queue)))
         for index, item in enumerate(self.__sched_obj.queue):
-            print('Event %d' %index, item)
+            print('Event {0:d} {1}'.format(index, item))
         print('*' * 20)
 
     # @instance: would be date or delta timesec


### PR DESCRIPTION
Since 3.x version, Python import a new formatting style to extend
original one. However, both are compactible but official 3.6 doc
had marked as a old method for string formating \[1\].

\[1\]: https://docs.python.org/3/tutorial/inputoutput.html#old-string-formatting