### PR TITLE
Enable verbose mode for unittest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ all:
 	true
 
 %_test:
-	$(PYTHON) -m unittest $(TEST).$@
+	$(PYTHON) -m -v unittest $(TEST).$@
 
 check:
-	$(PYTHON) -m unittest \
+	$(PYTHON) -m unittest -v \
 		$(TEST).scheduler_test \
 		$(TEST).roulette_test
 #		$(TEST).reader_test \


### PR DESCRIPTION
Before:
```
$ make check 
python3 -m unittest \
	tests.scheduler_test \
	tests.roulette_test
..
----------------------------------------------------------------------
Ran 2 tests in 9.002s

OK
```

After:
```
$ make check 
python3 -m unittest -v \
	tests.scheduler_test \
	tests.roulette_test
test_order (tests.scheduler_test.SchedulerTestcase) ... ok
test_shift_policy (tests.roulette_test.RouletteTestcase) ... ok

----------------------------------------------------------------------
Ran 2 tests in 9.002s

OK
```