### PR TITLE
Tweak class member attributes from privacy to readonly

### DIFF
--- a/roulette/roulette.py
+++ b/roulette/roulette.py
@@ -1,9 +1,9 @@
 class Roulette():
     def __init__(self, policy, cands = ()):
         # Declaration
-        self.__policy = None
-        self.__candidates = None
-        self.__ptr = None
+#        self.__policy = None
+#        self.__candidates = None
+#        self.__ptr = None
 
         # Initialization
         self.setUp(policy, cands)
@@ -16,3 +16,11 @@ class Roulette():
     def lottery(self):
         self.__ptr = self.__policy(self.__ptr, self.__candidates)
         return self.__ptr
+
+    @property
+    def policy(self):
+        return self.__policy
+
+    @property
+    def candidates(self):
+        return self.__candidates


### PR DESCRIPTION
It's OK to expose policy and candiates of roulette object to users.
But no write permission for those, users should call `setUp` method
to update the configuration.