### PR TITLE
Fix improper order of argument passing for single testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all:
 	true
 
 %_test:
-	$(PYTHON) -m -v unittest $(TEST).$@
+	$(PYTHON) -m unittest -v $(TEST).$@
 
 check:
 	$(PYTHON) -m unittest -v \


### PR DESCRIPTION
Single test via Makefile doesn't work due to the improper order of argument passing.